### PR TITLE
Speed Improvements for when we know that the data is new or existing

### DIFF
--- a/src/main/java/com/activeandroid/Model.java
+++ b/src/main/java/com/activeandroid/Model.java
@@ -61,6 +61,10 @@ public abstract class Model implements IModel{
         SQLiteUtils.save(this);
 	}
 
+    public final void save(int mode) {
+        SQLiteUtils.save(this, mode);
+    }
+
     @Override
     public boolean exists(){
         return SQLiteUtils.exists(this);

--- a/src/main/java/com/activeandroid/runtime/DBRequestQueue.java
+++ b/src/main/java/com/activeandroid/runtime/DBRequestQueue.java
@@ -52,7 +52,9 @@ public class DBRequestQueue extends Thread{
             }
 
             try{
-                AALog.d("DBRequestQueue + " + getName(), "Size is: " + mQueue.size() + " executing:" + runnable.getName());
+                if(AALog.isEnabled()) {
+                    AALog.d("DBRequestQueue + " + getName(), "Size is: " + mQueue.size() + " executing:" + runnable.getName());
+                }
                 runnable.run();
             } catch (Throwable t){
                 throw new RuntimeException(t);

--- a/src/main/java/com/activeandroid/util/SQLiteUtils.java
+++ b/src/main/java/com/activeandroid/util/SQLiteUtils.java
@@ -381,7 +381,38 @@ public final class SQLiteUtils {
                 .notifyChange(ContentProvider.createUri(tableInfo.getType(), IModel.getId()), null);
     }
 
-    public static void save(IModel IModel){
+
+    /**
+     *  {@link #save(com.activeandroid.IModel, int)} will check for the model to exist before inserting or updating
+     */
+    public static final int MODE_DEFAULT = 0;
+
+    /**
+     *  Used in {@link #save(com.activeandroid.IModel, int)}, we know the data is not new so we will update it all.
+     *  If it does not do anything, we will insert it
+     */
+    public static final int MODE_UPDATE = 1;
+
+    /**
+     * We will only attempt to insert the data into the DB
+     */
+    public static final int MODE_INSERT = 3;
+
+
+    /**
+     * Saves the given {@link com.activeandroid.IModel} to the DB with {@link #MODE_DEFAULT}
+     * @param iModel
+     */
+    public static void save(IModel iModel) {
+        save(iModel, MODE_DEFAULT);
+    }
+
+    /**
+     * Saves the given {@link com.activeandroid.IModel} to the DB.
+     * @param IModel
+     * @param mode
+     */
+    public static void save(IModel IModel, int mode){
         TableInfo tableInfo = Cache.getTableInfo(IModel.getClass());
         final SQLiteDatabase db = Cache.openDatabase();
         final ContentValues values = new ContentValues();
@@ -466,9 +497,19 @@ public final class SQLiteUtils {
             }
         }
 
-        if(!IModel.exists()){
-            IModel.setRowId(db.insert(tableInfo.getTableName(), null, values));
+        boolean exists = false;
+        if(mode == MODE_DEFAULT ) {
+            exists = exists(IModel);
+        } else if(mode == MODE_UPDATE) {
+            exists = true;
+        }
 
+        if(exists) {
+            exists = (db.update(tableInfo.getTableName(), values, SQLiteUtils.getWhereStatement(IModel, tableInfo), null) != 0);
+        }
+
+        if(!exists) {
+            IModel.setRowId(db.insert(tableInfo.getTableName(), null, values));
             for(Field field : tableInfo.getPrimaryKeys()){
                 if(field.isAnnotationPresent(PrimaryKey.class) &&
                         field.getAnnotation(PrimaryKey.class).type().equals(PrimaryKey.Type.AUTO_INCREMENT)){
@@ -480,8 +521,6 @@ public final class SQLiteUtils {
                     }
                 }
             }
-        } else {
-            IModel.setRowId(db.update(tableInfo.getTableName(), values, SQLiteUtils.getWhereStatement(IModel, tableInfo), null));
         }
 
         Cache.getContext().getContentResolver()


### PR DESCRIPTION
added check for log enabled before showing log to prevent getting size of the list for every queued item if we're not debugging. also added a param for optimizing how we save to the DB so that we can speed up inserts for a clean new item in the DB.
